### PR TITLE
Include compatibility for Debian 12

### DIFF
--- a/install/setup_os.sh
+++ b/install/setup_os.sh
@@ -15,6 +15,22 @@ function os_err() {
     exit -1
 }
 
+function debian_12_lts() {
+    echo "Installing dependencies (requires sudo privileges)"
+    apt-get update
+    apt-get install -y --no-install-recommends \
+            python3 \
+            r-base \
+            emacs \
+            texlive-latex-extra \
+            texlive-science \
+            texlive-xetex \
+            texlive-luatex \
+            texlive-plain-generic \
+            latexmk
+}
+
+
 function ubuntu_20043_lts() {
     echo "Installing dependencies (requires sudo privileges)"
     apt-get update
@@ -41,6 +57,10 @@ function debian_109() {
 
 function debian_11() {
     ubuntu_20043_lts
+}
+
+function debian_12() {
+    debian_12_lts
 }
 
 function centos_8() {
@@ -126,11 +146,19 @@ function check_os_eval() {
                     os_installing
                     debian_11
                     ;;
+		"12 (bookworm)")
+                    os_installing
+                    debian_12
+                    ;;
                 "")
                     case "$OS_PRETTY" in
                         "Debian GNU/Linux bullseye/sid")
                             os_installing
                             debian_11
+                            ;;
+                        "Debian GNU/Linux 12 (bookworm)")
+                            os_installing
+                            debian_12
                             ;;
                         *)
                             os_err


### PR DESCRIPTION
Add the installation commands for Debian 12, with the following modifications: 
- removing python (deprecated), 
- removing julia (it can not be installed on Debian only by that) packages, 
- including texlive-plain-generic (to solve the problem: ! LaTeX Error: File `ulem.sty' not found.)